### PR TITLE
Added Pin.lock() method

### DIFF
--- a/src/Pin/index.js
+++ b/src/Pin/index.js
@@ -130,4 +130,19 @@ export default {
       }
     })
   },
+ lock(context){
+    return new Promise((resolve, reject) => {
+      try {
+        context = contextCheck(context)
+        if (context) {
+          unlocked = false
+          resolve(!!!unlocked)
+        } else {
+          reject('Incorrect Context provided')
+        }
+      } catch (e) {
+        reject(e)
+      }
+    })
+  },
 }


### PR DESCRIPTION
In current Pin plugin, we can only check the status of pin plugin and submit the password to get it unlocked.  But once it is unlocked, even after restarting the app it is in unlock state only. To get it locked, we can use this lock() method.

To get the Pin plugin locked again, we have to use Pin.lock(context)

This PR fixes #11